### PR TITLE
Update Fluentd base image to 1.18.0-debian-12-r12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG FLUENTD_REPOSITORY=docker.io/bitnami/fluentd
-ARG FLUENTD_TAG=1.18.0-debian-12-r11
+ARG FLUENTD_TAG=1.18.0-debian-12-r12
 
 FROM ${FLUENTD_REPOSITORY}:${FLUENTD_TAG} AS builder
 


### PR DESCRIPTION
Updated the FLUENTD_TAG in the Dockerfile to use version 1.18.0-debian-12-r12, which is a newer revision of the Bitnami Fluentd base image.

The fluent-plugin-kinesis and fluent-plugin-opensearch plugins were already at their latest versions (3.5.0 and 1.1.5 respectively).