### PR TITLE
feat: Build multi-architecture Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This change modifies the GitHub workflow to build Docker images for both linux/amd64 and linux/arm64 architectures. This is achieved by adding the `platforms` input to the `docker/build-push-action` in the build workflow.